### PR TITLE
Feat keyword name

### DIFF
--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -207,7 +207,8 @@ agepro_model <- R6Class(
       }else {
         # Assert case_id R6class if value includes the "model_name"
         # (active binding) public field
-        checkmate::assert_r6(value, public = "model_name")
+        checkmate::assert_r6(value, public = "model_name",
+                             .var.name = "case_id")
         private$.case_id <- value
       }
     },

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -22,6 +22,7 @@ agepro_model <- R6Class(
     .ver_numeric_string = NULL,
 
     # AGEPRO keyword parameters
+    .case_id = NULL,
     .general_options = NULL,
     .natural_mortality = NULL,
     .maturity_fraction = NULL,
@@ -48,9 +49,6 @@ agepro_model <- R6Class(
 
     #' @field recruit AGEPRO Recruitmment Model(s)
     recruit = NULL,
-
-    #' @field case_id Case id
-    case_id = NULL,
 
     #' @field bootstrap Bootstrapping
     bootstrap = NULL,
@@ -198,6 +196,19 @@ agepro_model <- R6Class(
         #use as.numeric_version to validate
         cli::cli_alert_info("Version: {as.numeric_version(value)}")
         private$.ver_numeric_string <- value
+      }
+    },
+
+    #' @field case_id
+    #' Title identifying AGEPRO model attributes
+    case_id = function(value) {
+      if(missing(value)){
+        return(private$.case_id)
+      }else {
+        # Assert case_id R6class if value includes the "model_name"
+        # (active binding) public field
+        checkmate::assert_r6(value, public = "model_name")
+        private$.case_id <- value
       }
     },
 

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -24,6 +24,7 @@ agepro_model <- R6Class(
     # AGEPRO keyword parameters
     .case_id = NULL,
     .general_options = NULL,
+    .recruitment = NULL,
     .bootstrap = NULL,
     .natural_mortality = NULL,
     .maturity_fraction = NULL,
@@ -47,9 +48,6 @@ agepro_model <- R6Class(
 
   ),
   public = list(
-
-    #' @field recruit AGEPRO Recruitmment Model(s)
-    recruit = NULL,
 
     #' @description
     #' Starts an instances of the AGEPRO Model
@@ -328,6 +326,21 @@ agepro_model <- R6Class(
         checkmate::assert_r6(value, classes = "process_error")
         private$.discard_weight_age <- value
       }
+    },
+
+    #' @field recruit
+    #' AGEPRO Recruitment Model information
+    recruit = function(value) {
+     if(missing(value)) {
+       return(private$.recruitment)
+     }else {
+       #Check
+       checkmate::assert_r6(value, public = c("recruit_scaling_factor",
+                                              "ssb_scaling_factor",
+                                              "recruit_probability"),
+                            .var.name = "recruit")
+       private$.recruitment <- value
+     }
     }
 
   )

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -99,8 +99,6 @@ agepro_model <- R6Class(
 
       private$.discards_present <- self$general$discards_present
 
-      private$cli_recruit_rule()
-      cli_alert("Creating Default Recruitment Model")
       self$recruit <- recruitment$new(
         rep(0, self$general$num_rec_models), self$general$seq_years)
 

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -24,6 +24,7 @@ agepro_model <- R6Class(
     # AGEPRO keyword parameters
     .case_id = NULL,
     .general_options = NULL,
+    .bootstrap = NULL,
     .natural_mortality = NULL,
     .maturity_fraction = NULL,
     .fishery_selectivity = NULL,
@@ -49,10 +50,6 @@ agepro_model <- R6Class(
 
     #' @field recruit AGEPRO Recruitmment Model(s)
     recruit = NULL,
-
-    #' @field bootstrap Bootstrapping
-    bootstrap = NULL,
-
 
     #' @description
     #' Starts an instances of the AGEPRO Model
@@ -221,6 +218,17 @@ agepro_model <- R6Class(
       }else {
         checkmate::assert_r6(value)
         private$.general_options <- value
+      }
+    },
+
+    #' @field bootstrap
+    #' Bootstrapping
+    bootstrap = function(value) {
+      if(missing(value)){
+        return(private$.bootstrap)
+      }else {
+        checkmate::assert_r6(value, .var.name = "bootstrap")
+        private$.bootstrap <- value
       }
     },
 

--- a/R/case_id.R
+++ b/R/case_id.R
@@ -29,7 +29,7 @@ case_id <- R6Class(
     #' Prints out Model case id
     #'
     print = function() {
-      cli::cli_text("{self$case_id}")
+      cli::cli_text("{symbol$info} case_id: {.val {self$case_id}}")
     },
 
     #' @description
@@ -55,8 +55,6 @@ case_id <- R6Class(
         self$case_id
       ))
     }
-
-    #TODO: CASE ID print function
 
   ),
   active = list(

--- a/R/case_id.R
+++ b/R/case_id.R
@@ -16,7 +16,7 @@ case_id <- R6Class(
 
     .keyword_name = "caseid",
 
-    .caseid = NULL
+    .model_name = NULL
   ),
   public = list(
 
@@ -24,14 +24,15 @@ case_id <- R6Class(
     #' Initialize Class
     #'
     initalize = function() {
-      self$caseid <- NULL
+      self$model_name <- NULL
     },
 
     #' @description
     #' Prints out Model case id
     #'
     print = function() {
-      cli::cli_text("{symbol$info} case_id: {.val {self$caseid}}")
+      cli_keyword_heading(self$keyword_name)
+      cli::cli_text("{symbol$info} model_name: {.val {self$model_name}}")
     },
 
     #' @description
@@ -40,9 +41,9 @@ case_id <- R6Class(
     read_inp_lines = function(inp_con, nline) {
 
       nline <- nline + 1
-      self$case_id <- readLines(inp_con, n = 1, warn = FALSE)
-      #message("Line ", nline, ": Case ID: ", self$case_id)
-      cli::cli_alert("Line {nline}: CASE ID: {self$caseid}")
+      self$model_name <- readLines(inp_con, n = 1, warn = FALSE)
+
+      cli::cli_alert("Line {nline}: CASE ID: {self$model_name}")
       return(nline)
     },
 
@@ -54,19 +55,20 @@ case_id <- R6Class(
     inplines_case_id = function() {
       return(list(
         self$inp_keyword,
-        self$caseid
+        self$model_name
       ))
     }
 
   ),
   active = list(
 
-    #' @field caseid case id
-    caseid = function(val) {
+    #' @field model_name
+    #' String that describes the projection model run
+    model_name = function(val) {
       if (missing(val)) {
-        return(private$.caseid)
+        return(private$.model_name)
       }else {
-        private$.caseid <- val
+        private$.model_name <- val
       }
     },
 

--- a/R/case_id.R
+++ b/R/case_id.R
@@ -16,20 +16,22 @@ case_id <- R6Class(
 
     .keyword_name = "caseid",
 
-    .case_id = NULL
+    .caseid = NULL
   ),
   public = list(
 
-    #' @description Initalize
+    #' @description
+    #' Initialize Class
+    #'
     initalize = function() {
-      self$case_id <- private$.case_id
+      self$caseid <- NULL
     },
 
     #' @description
     #' Prints out Model case id
     #'
     print = function() {
-      cli::cli_text("{symbol$info} case_id: {.val {self$case_id}}")
+      cli::cli_text("{symbol$info} case_id: {.val {self$caseid}}")
     },
 
     #' @description
@@ -40,7 +42,7 @@ case_id <- R6Class(
       nline <- nline + 1
       self$case_id <- readLines(inp_con, n = 1, warn = FALSE)
       #message("Line ", nline, ": Case ID: ", self$case_id)
-      cli::cli_alert("Line {nline}: CASE ID: {self$case_id}")
+      cli::cli_alert("Line {nline}: CASE ID: {self$caseid}")
       return(nline)
     },
 
@@ -52,19 +54,19 @@ case_id <- R6Class(
     inplines_case_id = function() {
       return(list(
         self$inp_keyword,
-        self$case_id
+        self$caseid
       ))
     }
 
   ),
   active = list(
 
-    #' @field case_id case id
-    case_id = function(val) {
+    #' @field caseid case id
+    caseid = function(val) {
       if (missing(val)) {
-        return(private$.case_id)
+        return(private$.caseid)
       }else {
-        private$.case_id <- val
+        private$.caseid <- val
       }
     },
 

--- a/R/case_id.R
+++ b/R/case_id.R
@@ -13,6 +13,9 @@
 case_id <- R6Class(
   "case_id",
   private = list(
+
+    .keyword_name = "caseid",
+
     .case_id = NULL
   ),
   public = list(
@@ -48,7 +51,7 @@ case_id <- R6Class(
     #'
     inplines_case_id = function() {
       return(list(
-        "[CASEID]",
+        self$inp_keyword,
         self$case_id
       ))
     }
@@ -65,6 +68,18 @@ case_id <- R6Class(
       }else {
         private$.case_id <- val
       }
+    },
+
+    #' @field keyword_name
+    #' AGEPRO keyword parameter name
+    keyword_name = function() {
+      private$.keyword_name
+    },
+
+    #' @field inp_keyword
+    #' Returns AGEPRO input-file formatted Parameter
+    inp_keyword = function() {
+      paste0("[",toupper(private$.keyword_name),"]")
     }
   )
 )

--- a/R/general_params.R
+++ b/R/general_params.R
@@ -104,15 +104,13 @@ general_params <- R6Class(
     #' @description
     #' Reads General AGEPRO parameters from AGEPRO INP Input File
     read_inp_lines = function(inp_con, nline) {
+
       # Read an additional line from the file connection and split the string
       # into substrings by whitespace
-      inp_line <-
-        unlist(strsplit(readLines(inp_con, n = 1, warn = FALSE), " +"))
-
-      nline <- nline + 1
+      nine <- nline + 1
       cli_alert("Line {nline} : Reading AGEPRO model GENERAL options ...")
 
-      inp_line <- assert_numeric_substrings(inp_line)
+      inp_line <- read_inp_numeric_line(inp_con)
 
       self$yr_start <- inp_line[1]
       self$yr_end <- inp_line[2]

--- a/R/general_params.R
+++ b/R/general_params.R
@@ -17,7 +17,15 @@
 #' @importFrom checkmate test_logical assert_number
 general_params <- R6Class(
   classname = "general_params",
-
+  private = list(
+    cli_general_rule = function() {
+      d <- cli_div(theme = list(rule = list(
+        color = "cyan",
+        "line-type" = "double")))
+      cli_rule("General")
+      cli_end(d)
+    }
+  ),
   public = list(
     #' @field yr_start First Year in Projection
     yr_start = NULL,
@@ -204,18 +212,6 @@ general_params <- R6Class(
       ))
     }
 
-
-
-
-
-  ), private = list(
-    cli_general_rule = function() {
-      d <- cli_div(theme = list(rule = list(
-          color = "cyan",
-          "line-type" = "double")))
-      cli_rule("General")
-      cli_end(d)
-    }
   )
 
 )

--- a/R/general_params.R
+++ b/R/general_params.R
@@ -29,14 +29,8 @@ general_params <- R6Class(
     .discards_present = NULL,
     .seed = NULL,
 
+    .keyword_name = "general"
 
-    cli_general_rule = function() {
-      d <- cli_div(theme = list(rule = list(
-        color = "cyan",
-        "line-type" = "double")))
-      cli_rule("General")
-      cli_end(d)
-    }
   ),
   public = list(
 
@@ -63,7 +57,8 @@ general_params <- R6Class(
                           discards_present = FALSE,
                           seed = sample.int(1e8, 1)) {
 
-      private$cli_general_rule()
+
+      cli_keyword_heading(self$keyword_name)
       # Discards: Assert numeric format
       if (test_logical(discards_present)) {
         discards_present <- as.numeric(discards_present)
@@ -133,7 +128,7 @@ general_params <- R6Class(
     #'
     inplines_general = function(delimiter = "  ") {
       return(list(
-        "[GENERAL]",
+        self$inp_keyword,
         paste(self$yr_start,
               self$yr_end,
               self$age_begin,
@@ -276,6 +271,18 @@ general_params <- R6Class(
     #' projection
     seq_years = function() {
       seq(self$yr_start, self$yr_end)
+    },
+
+    #' @field keyword_name
+    #' AGEPRO keyword parameter name
+    keyword_name = function() {
+      private$.keyword_name
+    },
+
+    #' @field inp_keyword
+    #' Returns AGEPRO input-file formatted Parameter
+    inp_keyword = function() {
+      paste0("[",toupper(private$.keyword_name),"]")
     },
 
     #' @field json_list_general

--- a/R/general_params.R
+++ b/R/general_params.R
@@ -18,6 +18,18 @@
 general_params <- R6Class(
   classname = "general_params",
   private = list(
+
+    .yr_start = NULL,
+    .yr_end = NULL,
+    .age_begin = NULL,
+    .age_end = NULL,
+    .num_fleets = NULL,
+    .num_rec_models = NULL,
+    .num_pop_sims = NULL,
+    .discards_present = NULL,
+    .seed = NULL,
+
+
     cli_general_rule = function() {
       d <- cli_div(theme = list(rule = list(
         color = "cyan",
@@ -27,35 +39,6 @@ general_params <- R6Class(
     }
   ),
   public = list(
-    #' @field yr_start First Year in Projection
-    yr_start = NULL,
-
-    #' @field yr_end Last Year in Projection
-    yr_end = NULL,
-
-    #' @field age_begin First Age Class
-    age_begin = NULL,
-
-    #' @field age_end Last Age Class
-    age_end = NULL,
-
-    #' @field num_fleets Number of Fleets
-    num_fleets = NULL,
-
-    #' @field num_rec_models Number of Recruitment Models
-    num_rec_models = NULL,
-
-    #' @field num_pop_sims Number of Population Simulations
-    num_pop_sims = NULL,
-
-    #' @field discards_present Are discards present?
-    discards_present = NULL,
-
-    #' @field seed Psuedorandom number seed
-    seed = NULL,
-
-    #' @field inp_file File name of opened/imported input file
-    inp_file = NULL,
 
     #' @description
     #' Starts an instances of the AGEPRO Model
@@ -81,21 +64,20 @@ general_params <- R6Class(
                           seed = sample.int(1e8, 1)) {
 
       private$cli_general_rule()
-      # Discards: Assert logical format
-      if (!test_logical(discards_present)) {
-        assert_number(discards_present, lower = 0, upper = 1)
-        discards_present <- as.logical(discards_present)
+      # Discards: Assert numeric format
+      if (test_logical(discards_present)) {
+        discards_present <- as.numeric(discards_present)
       }
 
-      self$yr_start <- yr_start
-      self$yr_end <- yr_end
-      self$age_begin <- age_begin
-      self$age_end <- age_end
-      self$num_pop_sims <- num_pop_sims
-      self$num_fleets <- num_fleets
-      self$num_rec_models <- num_rec_models
+      self$yr_start <- as.numeric(yr_start)
+      self$yr_end <- as.numeric(yr_end)
+      self$age_begin <- as.numeric(age_begin)
+      self$age_end <- as.numeric(age_end)
+      self$num_pop_sims <- as.numeric(num_pop_sims)
+      self$num_fleets <- as.numeric(num_fleets)
+      self$num_rec_models <- as.numeric(num_rec_models)
       self$discards_present <- discards_present
-      self$seed <- seed
+      self$seed <- as.numeric(seed)
 
       self$print()
 
@@ -132,7 +114,6 @@ general_params <- R6Class(
 
       inp_line <- assert_numeric_substrings(inp_line)
 
-      #TODO: Refactor
       self$yr_start <- inp_line[1]
       self$yr_end <- inp_line[2]
       self$age_begin <- inp_line[3]
@@ -170,6 +151,116 @@ general_params <- R6Class(
 
   ),
   active = list(
+
+    #' @field yr_start
+    #' First Year in Projection
+    yr_start = function(value) {
+      if(missing(value)){
+        private$.yr_start
+      }else {
+        checkmate::assert_numeric(value, lower = 0, len = 1,
+                                  .var.name = "yr_start")
+        private$.yr_start <- value
+      }
+    },
+
+    #' @field yr_end
+    #' Last Year in Projection
+    yr_end = function(value) {
+      if(missing(value)) {
+        private$.yr_end
+      }else {
+        checkmate::assert_numeric(value, lower = 1, len = 1,
+                                  .var.name = "yr_end")
+        private$.yr_end <- value
+      }
+    },
+
+    #' @field age_begin
+    #' First Age Class
+    age_begin = function(value){
+      if(missing(value)){
+        private$.age_begin
+      }else {
+        checkmate::assert_numeric(value, lower = 0, upper = 1, len = 1,
+                                  .var.name = "age_begin")
+        private$.age_begin <- value
+      }
+    },
+
+    #' @field age_end
+    #' Last Age Class
+    age_end = function(value){
+      if(missing(value)){
+        private$.age_end
+      }else {
+        checkmate::assert_numeric(value, len = 1,
+                                  .var.name = "age_end")
+        private$.age_end <- value
+      }
+    },
+
+    #' @field num_fleets
+    #' Number of Fleets
+    num_fleets = function(value){
+      if(missing(value)){
+        private$.num_fleets
+      }else {
+        checkmate::assert_numeric(value, lower = 1, len = 1,
+                                  .var.name = "num_fleets")
+        private$.num_fleets <- value
+      }
+    },
+
+    #' @field num_rec_models
+    #' Number of Recruitment Models
+    num_rec_models = function(value) {
+      if(missing(value)) {
+        private$.num_rec_models
+      }else {
+        checkmate::assert_numeric(value, lower = 1, len = 1,
+                                  .var.name = "num_rec_models")
+        private$.num_rec_models <- value
+      }
+    },
+
+    #' @field num_pop_sims
+    #' Number of Population Simulations
+    num_pop_sims = function(value){
+      if(missing(value)) {
+        private$.num_pop_sims
+      }else {
+        checkmate::assert_numeric(value, lower = 0, len = 1,
+                                  .var.name = "num_pop_sims")
+        private$.num_pop_sims <- value
+      }
+    },
+
+    #' @field discards_present
+    #' Are discards present?
+    discards_present = function(value) {
+      if(missing(value)) {
+        private$.discards_present
+      }else {
+        #set discard_present values as int/numeric. 0=FALSE 1=TRUE
+        checkmate::assert_numeric(value, lower = 0, upper = 1, len = 1,
+                                  .var.name = "discards_present")
+        private$.discards_present <- value
+      }
+    },
+
+    #' @field seed
+    #' Pseudo Random Number seed
+    seed = function(value){
+      if(missing(value)) {
+        private$.seed
+      }else {
+        checkmate::assert_numeric(value, len = 1,
+                                  .var.name = "seed")
+        private$.seed <- value
+      }
+    },
+
 
     #' @field num_years Determines the number of years in projection by the
     #' (absolute) difference of the last and first year of projection.

--- a/R/recruitment.R
+++ b/R/recruitment.R
@@ -35,13 +35,14 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
 
     .recruit_scaling_factor = NULL,
     .ssb_scaling_factor = NULL,
+    .model_collection_list = NULL,
 
     .recruit_probability = NULL,
     .recruit_model_num_list = NULL,
 
 
+    #Module to printout Recruitment probability to Rconsole
     cli_recruit_probability = function() {
-      #Module to printout Recruitment probability to Rconsole
       cli_alert_info("Recruitment Probability:")
       assert_list(private$.recruit_probability) #verify recruit_prob list
       cat_print(private$.recruit_probability)
@@ -63,6 +64,9 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
 
     },
 
+    # Helper function to help setup .number_recruit_models,
+    # recruit_model_num_list, & model_collection_list vectors
+    # based on `model_num`.
     setup_recruitment_list_vectors = function(model_num) {
 
       # Setup number of recruits based on the vector length of the recruitment
@@ -109,13 +113,6 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
 
   ), public = list(
 
-    #' @field recruit_model_num_list Recruitment Type
-    recruit_model_num_list = NULL,
-
-    #' @field model_collection_list List of recruitment models. Use this field
-    #' to access a specific recruitment models field.
-    model_collection_list = NULL,
-
     #' @field observation_years Sequence of projected years
     observation_years = NULL,
 
@@ -139,7 +136,8 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
       # Handle seq_years as a single int or a vector of sequential values
       private$assert_observed_years(seq_years)
 
-      # Setup .number_recruit_models vectors
+      ## Sets up recruitment vectors:
+      # .number_recruit_models, recruit_model_num_list, model_collection_list
       private$setup_recruitment_list_vectors(model_num)
 
       # Setup Recruitment probability
@@ -168,7 +166,8 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
     #' Creates Recruitment Model Data
     set_recruit_data = function(model_num) {
 
-      # Setup .number_recruit_models vectors
+      ## Sets up recruitment vectors:
+      # .number_recruit_models, recruit_model_num_list, model_collection_list
       private$setup_recruitment_list_vectors(model_num)
 
       #Set recruitment probability and model data for each recruitment model.
@@ -293,17 +292,6 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
       cli_end()
     },
 
-    #TODO: Create a active field function for showing model_collection_list
-
-    #' @description
-    #' Helper Function To View Recruitment Model Collection Data
-    view_recruit_data = function() {
-
-      cli_alert_info(paste0("Recruitment Model{?s}: ",
-                            "{.field {self$recuit_model_num_list}} "))
-
-    },
-
     #' @description
     #' Reads in Recruitment AGEPRO parameters from AGEPRO INP Input File
     read_inp_lines = function(inp_con, nline) {
@@ -348,8 +336,9 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
       #?Validate length Recruitment's recruit_model_num_list matches
       #length of recruitment models field from the set_recruit_data function
 
-      ## Setup for .number_recruit_models and recruitment list vectors:
-      # recruit_model_mum_list, .recruit_probability, & model_collection_list
+      ## Setup for recruitment list vectors:
+      # .number_recruit_models, recruit_model_mum_list,.recruit_probability,
+      # model_collection_list
       private$setup_recruitment_list_vectors(inp_line)
 
       # Setup Default Recruitment probability
@@ -467,6 +456,33 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
     #' The Recruitment Probabilities.
     recruit_probability = function() {
       return(private$.recruit_probability)
+    },
+
+
+    #TODO: Create a active field function for showing model_collection_list
+
+    #' @field model_collection_list
+    #' List of recruitment models. Use this field
+    #' to access a specific recruitment models field.
+    model_collection_list = function(value) {
+      if(missing(value)){
+        return(private$.model_collection_list)
+      } else{
+        checkmate::assert_list(value, .var.name = "model_collection_list")
+        private$.model_collection_list <- value
+      }
+    },
+
+    #' @field recruit_model_num_list
+    #' Helper Function To View Recruitment Model Collection Data
+    recruit_model_num_list = function(value) {
+      if(missing(value)){
+        return(private$.recruit_model_num_list)
+      } else{
+        checkmate::assert_list(value, types = c("numeric","null"),
+                               .var.name = "recruit_model_num_list")
+        private$.recruit_model_num_list <- value
+      }
     },
 
     #' @field num_recruit_models

--- a/R/recruitment.R
+++ b/R/recruitment.R
@@ -31,21 +31,14 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
     .sequence_projection_years = NULL,
     .max_rec_obs = 10000,
 
+    .keyword_name = "recruit",
+
     .recruit_scaling_factor = NULL,
     .ssb_scaling_factor = NULL,
 
     .recruit_probability = NULL,
     .recruit_model_num_list = NULL,
 
-
-
-    cli_recruit_rule = function() {
-      d <- cli_div(theme = list(rule = list(
-        color = "cyan",
-        "line-type" = "double")))
-      cli_rule("Recruitment")
-      cli_end(d)
-    },
 
     cli_recruit_probability = function() {
       #Module to printout Recruitment probability to Rconsole
@@ -162,7 +155,9 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
         private$.max_rec_obs <- max_rec_obs
       }
 
-
+      # 'recruit' cli messages at initialization
+      cli_keyword_heading(self$keyword_name)
+      cli_alert("Creating Default Recruitment Model")
       self$print(cat_verbose)
 
 
@@ -439,7 +434,7 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
           how = "list")))
 
       return(c(list(
-        "[RECRUIT]",
+        self$inp_keyword,
         paste(
           self$recruit_scaling_factor,
           self$ssb_scaling_factor,
@@ -528,6 +523,18 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
         prob = self$recruit_probability,
         recruitData = recruit_model_data_list))
 
+    },
+
+    #' @field keyword_name
+    #' AGEPRO keyword parameter name
+    keyword_name = function() {
+      private$.keyword_name
+    },
+
+    #' @field inp_keyword
+    #' Returns AGEPRO input-file formatted Parameter
+    inp_keyword = function() {
+      paste0("[",toupper(private$.keyword_name),"]")
     }
 
   )

--- a/man/agepro_model.Rd
+++ b/man/agepro_model.Rd
@@ -16,8 +16,6 @@ determine age-structured population over a time period. Brodziak, 2022
 \describe{
 \item{\code{recruit}}{AGEPRO Recruitmment Model(s)}
 
-\item{\code{case_id}}{Case id}
-
 \item{\code{bootstrap}}{Bootstrapping}
 }
 \if{html}{\out{</div>}}
@@ -29,6 +27,8 @@ determine age-structured population over a time period. Brodziak, 2022
 with Jon Brodiak's AGEPRO calculation engine.}
 
 \item{\code{ver_numeric_string}}{Numeric character string based by Semantic-like versioning format.}
+
+\item{\code{case_id}}{Title identifying AGEPRO model attributes}
 
 \item{\code{general}}{General Options}
 

--- a/man/agepro_model.Rd
+++ b/man/agepro_model.Rd
@@ -11,13 +11,6 @@ of fleets, recruitment, and uncertainties
 AGEPRO performs stochastic projections on exploited fisheries stock to
 determine age-structured population over a time period. Brodziak, 2022
 }
-\section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{recruit}}{AGEPRO Recruitmment Model(s)}
-}
-\if{html}{\out{</div>}}
-}
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
@@ -51,6 +44,8 @@ Discard Fraction}
 \item{\code{catch_weight}}{Landed catch weight at age by fleet}
 
 \item{\code{disc_weight}}{Discard weight of age by fleet}
+
+\item{\code{recruit}}{AGEPRO Recruitment Model information}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/agepro_model.Rd
+++ b/man/agepro_model.Rd
@@ -15,8 +15,6 @@ determine age-structured population over a time period. Brodziak, 2022
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
 \item{\code{recruit}}{AGEPRO Recruitmment Model(s)}
-
-\item{\code{bootstrap}}{Bootstrapping}
 }
 \if{html}{\out{</div>}}
 }
@@ -31,6 +29,8 @@ with Jon Brodiak's AGEPRO calculation engine.}
 \item{\code{case_id}}{Title identifying AGEPRO model attributes}
 
 \item{\code{general}}{General Options}
+
+\item{\code{bootstrap}}{Bootstrapping}
 
 \item{\code{natmort}}{Natural Mortality}
 

--- a/man/case_id.Rd
+++ b/man/case_id.Rd
@@ -9,7 +9,7 @@ Input title identifying model attributes
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{caseid}}{case id}
+\item{\code{model_name}}{String that describes the projection model run}
 
 \item{\code{keyword_name}}{AGEPRO keyword parameter name}
 

--- a/man/case_id.Rd
+++ b/man/case_id.Rd
@@ -9,7 +9,7 @@ Input title identifying model attributes
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{case_id}}{case id}
+\item{\code{caseid}}{case id}
 
 \item{\code{keyword_name}}{AGEPRO keyword parameter name}
 
@@ -31,7 +31,7 @@ Input title identifying model attributes
 \if{html}{\out{<a id="method-case_id-initalize"></a>}}
 \if{latex}{\out{\hypertarget{method-case_id-initalize}{}}}
 \subsection{Method \code{initalize()}}{
-Initalize
+Initialize Class
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{case_id$initalize()}\if{html}{\out{</div>}}
 }

--- a/man/case_id.Rd
+++ b/man/case_id.Rd
@@ -10,6 +10,10 @@ Input title identifying model attributes
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
 \item{\code{case_id}}{case id}
+
+\item{\code{keyword_name}}{AGEPRO keyword parameter name}
+
+\item{\code{inp_keyword}}{Returns AGEPRO input-file formatted Parameter}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/general_params.Rd
+++ b/man/general_params.Rd
@@ -9,8 +9,8 @@ the projection time horizon, the target model's age class range, the
 quantity of recruitment models used, and fishery processes that affect
 projections.
 }
-\section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
+\section{Active bindings}{
+\if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
 \item{\code{yr_start}}{First Year in Projection}
 
@@ -28,15 +28,8 @@ projections.
 
 \item{\code{discards_present}}{Are discards present?}
 
-\item{\code{seed}}{Psuedorandom number seed}
+\item{\code{seed}}{Pseudo Random Number seed}
 
-\item{\code{inp_file}}{File name of opened/imported input file}
-}
-\if{html}{\out{</div>}}
-}
-\section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
 \item{\code{num_years}}{Determines the number of years in projection by the
 (absolute) difference of the last and first year of projection.}
 

--- a/man/general_params.Rd
+++ b/man/general_params.Rd
@@ -39,6 +39,10 @@ of the first and last age class.}
 \item{\code{seq_years}}{Returns a sequence of years from First year of
 projection}
 
+\item{\code{keyword_name}}{AGEPRO keyword parameter name}
+
+\item{\code{inp_keyword}}{Returns AGEPRO input-file formatted Parameter}
+
 \item{\code{json_list_general}}{List of GENERAL keyword fields values, exportable to JSON.}
 }
 \if{html}{\out{</div>}}

--- a/man/recruitment.Rd
+++ b/man/recruitment.Rd
@@ -37,6 +37,10 @@ absolute numbers of fish}
 spawning weight of fish in kilograms (kg)}
 
 \item{\code{json_list_recruit}}{List of RECRUIT keyword fields values, exportable to JSON.}
+
+\item{\code{keyword_name}}{AGEPRO keyword parameter name}
+
+\item{\code{inp_keyword}}{Returns AGEPRO input-file formatted Parameter}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/recruitment.Rd
+++ b/man/recruitment.Rd
@@ -12,11 +12,6 @@ these models.
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
-\item{\code{recruit_model_num_list}}{Recruitment Type}
-
-\item{\code{model_collection_list}}{List of recruitment models. Use this field
-to access a specific recruitment models field.}
-
 \item{\code{observation_years}}{Sequence of projected years}
 }
 \if{html}{\out{</div>}}
@@ -27,6 +22,11 @@ to access a specific recruitment models field.}
 \item{\code{max_recruit_obs}}{Recruitment submodel's maximum number of observations}
 
 \item{\code{recruit_probability}}{The Recruitment Probabilities.}
+
+\item{\code{model_collection_list}}{List of recruitment models. Use this field
+to access a specific recruitment models field.}
+
+\item{\code{recruit_model_num_list}}{Helper Function To View Recruitment Model Collection Data}
 
 \item{\code{num_recruit_models}}{Returns number of recruitment models}
 
@@ -52,7 +52,6 @@ spawning weight of fish in kilograms (kg)}
 \item \href{#method-recruitment-set_recruit_model}{\code{recruitment$set_recruit_model()}}
 \item \href{#method-recruitment-set_recruit_probability}{\code{recruitment$set_recruit_probability()}}
 \item \href{#method-recruitment-print}{\code{recruitment$print()}}
-\item \href{#method-recruitment-view_recruit_data}{\code{recruitment$view_recruit_data()}}
 \item \href{#method-recruitment-read_inp_lines}{\code{recruitment$read_inp_lines()}}
 \item \href{#method-recruitment-inplines_recruit}{\code{recruitment$inplines_recruit()}}
 \item \href{#method-recruitment-clone}{\code{recruitment$clone()}}
@@ -166,16 +165,6 @@ console. Default is TRUE}
 }
 \if{html}{\out{</div>}}
 }
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-recruitment-view_recruit_data"></a>}}
-\if{latex}{\out{\hypertarget{method-recruitment-view_recruit_data}{}}}
-\subsection{Method \code{view_recruit_data()}}{
-Helper Function To View Recruitment Model Collection Data
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{recruitment$view_recruit_data()}\if{html}{\out{</div>}}
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-recruitment-read_inp_lines"></a>}}


### PR DESCRIPTION
Code refactoring of `case_id`, `bootstrap`, `general_params`, and `recruitment` 

## general_params
- format private members to top of class
- actively bind `general_param` fields: 
  - `yr_start`, `yr_end`, `age_begin`, `age_end`, `num_fleets`, `num_rec_models`,  `num_pop_sims`, `discards_present`, `seed`
- Added `keyword_name` and `inp_keyword` active binding
  - Refactored out `cli_general_rule` and used generalized `cli_header_keyword` instead  
- Fix handling of `discard_present` logicals: convert to numeric.
  - Initialized `general_params` fields will be numeric.
- refactor `read_inp_lines` to use `read_inp_numeric_line`

## case_id
- rename `case_id` field as `model_name` to avoid class name-field name confusion
- actively bind `case_id` to `agepro_model` R6class
- cli tweaks

## bootstrap 
- actively binded `bootstrap` to `agepro_model` R6Class

## recruitment
- actively binded `recruit` to `agepro_model` R6class
- Added `keyword_name` and `inp_keyword` active binding
  - Refactored out `cli_recruit_rule` and used generalized `cli_header_keyword` instead
- Actively binded `model_collection_list` and `recruit_model_number_list` to `recruitment` R6class
