### PR TITLE
Revert to AGEPRO VERSION 4.0 currentver_inpfile_string; refactor inpfile version string validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Collate: 
     'ageproR-package.R'
     'agepro_model.R'

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -939,11 +939,6 @@ agepro_inp_model <- R6Class(
     #'
     match_keyword = function(inp_line, inp_con) {
 
-      # TODO: ~~CASEID~~, ~~GENERAL~~, ~~RECRUIT~~, ~~STOCK_WEIGHT~~,
-      # ~~SSB_WEIGHT~~, ~~MEAN_WEIGHT~~, ~~CATCH_WEIGHT~~, ~~DISC_WEIGHT~~,
-      # ~~NATMORT~~, ~~MATURITY~~, ~~FISHERY~~, ~~DISCARD~~, ~~BIOLOGICAL~~,
-      # ~~BOOTSTRAP~~, ~~HARVEST~~, ~~REBUILD~~, ~~PSTAR~~
-
       #Tidy evaluation evaluate wrapper functions
       keyword_dict <- dict(list(
         "[CASEID]" = {

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -1375,7 +1375,7 @@ agepro_inp_model <- R6Class(
       if(isFALSE(is_model_currentver)) {
         cli::cli_alert_info(paste0(
           "Setting input file format (ver_inpfile_string) VERSION to",
-          " {private$.currentver_inpfile_string}."))
+          " {.val {private$.currentver_inpfile_string}}"))
         self$ver_inpfile_string <- private$.currentver_inpfile_string
 
         return()

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -907,8 +907,6 @@ agepro_inp_model <- R6Class(
     #'
     read_inpfile_values = function(inp_con) {
 
-      message("Check Version")
-
       #assert_inpfile_version: assume line 1 is version string
       self$nline <- 1
 
@@ -1332,19 +1330,34 @@ agepro_inp_model <- R6Class(
     # Helper function to validate AGEPRO Input File Version format is
     # supported_inpfile_version
     assert_inpfile_version = function(inp_line) {
-      assert_character(inp_line, len = 1)
+
+      checkmate::assert_character(inp_line, len = 1)
 
       cli::cli_alert_info("Version: '{inp_line}'")
-      if(inp_line %in% self$supported_inpfile_versions){
-        self$ver_inpfile_string <- inp_line
-      }else{
-        # Throw Unsupported Version Error Message
+
+      # Throw Error if VERSION string doesn't match supported
+      # AGEPRO Input File Version string formats
+      if(isFALSE(inp_line %in% self$supported_inpfile_versions)){
         stop(paste0(
           "This version of this input file is not supported: ",inp_line,
           "\n - Supported verion(s): ",
           paste(self$supported_inpfile_versions,collapse=", ")),
           call.= FALSE)
       }
+
+      # Throw Warning if (supported) VERSION string doesn't match
+      # "current version" AGEPRO Input file format
+      if(isFALSE(identical(self$ver_inpfile_string,
+                    private$.currentver_inpfile_string))){
+        warning(paste0(inp_line,
+                       " (Line 1 read from input file),",
+                       " does not match current version",
+                       " format string: ",private$.currentver_inpfile_string),
+                call. = FALSE)
+      }
+
+      self$ver_inpfile_string <- inp_line
+
 
     },
 

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -1070,7 +1070,7 @@ agepro_inp_model <- R6Class(
 
       private$write_inpfile_version(as_currentver)
 
-      tryCatch(
+      withCallingHandlers(
         {
           list_inp_lines <- c(
             self$ver_inpfile_string,
@@ -1115,6 +1115,9 @@ agepro_inp_model <- R6Class(
 
           )
 
+        },
+        error = function(cond) {
+          message("There was an error writing this file. \n", cond)
         }
 
       )

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -1354,24 +1354,27 @@ agepro_inp_model <- R6Class(
     # version
     write_inpfile_version = function(as_current = TRUE){
 
-
-
+      # Check agepro_model VERSION string matches "current version"
+      # of input file version format
       is_model_currentver <- identical(self$ver_inpfile_string,
                                      private$.currentver_inpfile_string)
 
-      if(isFALSE(as_current)){
-        if(isFALSE(is_model_currentver)){
-          warning(paste0("AGEPRO input file version does not match",
-                         "current input file version: ",
-                         private$.currentver_inpfile_string,".")    )
-        }
+      if(isFALSE(is_model_currentver)) {
+        cli::cli_alert_info(paste0(
+          "Setting input file format (ver_inpfile_string) VERSION to",
+          " {private$.currentver_inpfile_string}."))
+        self$ver_inpfile_string <- private$.currentver_inpfile_string
+
         return()
       }
 
-      if(isFALSE(is_model_currentver)) {
-        cli::cli_alert_info(
-          "Setting input file VERSION to {private$.currentver_inpfile_string}.")
-        self$ver_inpfile_string <- private$.currentver_inpfile_string
+      if(isFALSE(as_current)){
+        warning(paste0("AGEPRO input file version does not match",
+                       "current input file version: ",
+                       private$.currentver_inpfile_string,".")    )
+      }else{
+        cli::cli_alert_info(paste0("Input file format (ver_inpfile_string): ",
+                                   "{.val {self$ver_inpfile_string}}"))
       }
 
       return()

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -1075,7 +1075,7 @@ agepro_inp_model <- R6Class(
         }
       }
 
-      private$set_inpfile_version(as_currentver)
+      private$write_inpfile_version(as_currentver)
 
       tryCatch(
         {
@@ -1329,7 +1329,8 @@ agepro_inp_model <- R6Class(
     },
 
 
-    # Helper function to check AGEPRO Input File Version
+    # Helper function to validate AGEPRO Input File Version format is
+    # supported_inpfile_version
     assert_inpfile_version = function(inp_line) {
       assert_character(inp_line, len = 1)
 
@@ -1351,7 +1352,9 @@ agepro_inp_model <- R6Class(
     # Set Input File String based on preference on current AGEPRO input file
     # version. Warn for agepro model's version string doesn't match current
     # version
-    set_inpfile_version = function(as_current = TRUE){
+    write_inpfile_version = function(as_current = TRUE){
+
+
 
       is_model_currentver <- identical(self$ver_inpfile_string,
                                      private$.currentver_inpfile_string)

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -734,7 +734,17 @@ agepro_model <- R6Class(
                                        "output_data_frame"))
         private$.output_options <- value
       }
+    },
+
+    #' @field supported_inpfile_versions
+    #' Supported AGEPRO Input File formats
+    #'
+    supported_inpfile_versions = function(){
+      return(c(private$.currentver_inpfile_string,
+               "AGEPRO VERSION 4.0",
+               "AGEPRO VERSION 4.25"))
     }
+
 
   ),
   private = list(
@@ -742,7 +752,10 @@ agepro_model <- R6Class(
     .ver_inpfile_string = NULL,
     .ver_jsonfile_format = NULL,
     .ver_rpackage = NULL,
-    .currentver_inpfile_string = "AGEPRO VERSION 4.25",
+
+    #AGEPRO Input File version
+    .currentver_inpfile_string = "AGEPRO VERSION 4.0",
+
 
     # AGEPRO keyword parameters
     .case_id = NULL,
@@ -820,7 +833,6 @@ agepro_inp_model <- R6Class(
     #'
     initialize = function(enable_cat_print = FALSE) {
 
-      private$.pre_v4 <- FALSE
       private$.nline <- 0
       private$setup_ver_rpackage()
 
@@ -1138,9 +1150,6 @@ agepro_inp_model <- R6Class(
   ),
   private = list(
 
-    .pre_v4 = FALSE,
-    .supported_inp_versions = c("AGEPRO VERSION 4.0", "AGEPRO VERSION 4.25"),
-
     .nline = NULL,
 
     read_case_id = function(con, nline) {
@@ -1325,14 +1334,14 @@ agepro_inp_model <- R6Class(
       assert_character(inp_line, len = 1)
 
       cli::cli_alert_info("Version: '{inp_line}'")
-      if(inp_line %in% private$.supported_inp_versions){
+      if(inp_line %in% self$supported_inpfile_versions){
         self$ver_inpfile_string <- inp_line
       }else{
         # Throw Unsupported Version Error Message
         stop(paste0(
           "This version of this input file is not supported: ",inp_line,
           "\n - Supported verion(s): ",
-          paste(private$.supported_inp_versions,collapse=", ")),
+          paste(self$supported_inpfile_versions,collapse=", ")),
           call.= FALSE)
       }
 

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -1052,11 +1052,11 @@ agepro_inp_model <- R6Class(
     #' Writes AGEPRO keyword parameter data as a AGEPRO input file (*.inp)
     #'
     #' @param inpfile input file path
-    #' @param as_currentver As default, saves to the current version of the
-    #' AGEPRO input file format.
+    #' @param overwrite_as_currentver As default, overwrites version value to
+    #' to the current version of the AGEPRO input file format.
     #'
     write_inp = function(inpfile, delimiter = "  ",
-                         as_currentver = TRUE) {
+                         overwrite_as_currentver = TRUE) {
 
       if (missing(inpfile)) {
 
@@ -1068,7 +1068,7 @@ agepro_inp_model <- R6Class(
         }
       }
 
-      private$write_inpfile_version(as_currentver)
+      private$write_inpfile_version(overwrite_as_currentver)
 
       withCallingHandlers(
         {
@@ -1363,7 +1363,7 @@ agepro_inp_model <- R6Class(
     # Set Input File String based on preference on current AGEPRO input file
     # version. Warn for agepro model's version string doesn't match current
     # version
-    write_inpfile_version = function(as_current = TRUE){
+    write_inpfile_version = function(overwrite_as_currentver = TRUE){
 
       # Check agepro_model VERSION string matches "current version"
       # of input file version format
@@ -1371,22 +1371,34 @@ agepro_inp_model <- R6Class(
                                      private$.currentver_inpfile_string)
 
       if(isFALSE(is_model_currentver)) {
+
+
+        cli::cli_alert_warning(paste0(
+          "Model's input file format ",
+          "{.strong {self$ver_inpfile_string}} does not match ",
+          "{.emph current version} ",
+          "{.strong {private$.currentver_inpfile_string}} "))
+
+
+        if(isFALSE(overwrite_as_currentver)){
+          #Return/Escape function and send warning
+          warning(paste0("AGEPRO input file version does not match",
+                         "current input file version ",
+                         private$.currentver_inpfile_string,".")    )
+          return()
+        }
+
+        #Otherwise, set model's input file string to "current version"
         cli::cli_alert_info(paste0(
-          "Setting input file format (ver_inpfile_string) VERSION to",
+          "Overwiting model's input file format (ver_inpfile_string) to ",
+          "{.emph current version} ",
           " {.val {private$.currentver_inpfile_string}}"))
         self$ver_inpfile_string <- private$.currentver_inpfile_string
 
-        return()
       }
 
-      if(isFALSE(as_current)){
-        warning(paste0("AGEPRO input file version does not match",
-                       "current input file version: ",
-                       private$.currentver_inpfile_string,".")    )
-      }else{
-        cli::cli_alert_info(paste0("Input file format (ver_inpfile_string): ",
+      cli::cli_alert_info(paste0("Input file format (ver_inpfile_string): ",
                                    "{.val {self$ver_inpfile_string}}"))
-      }
 
       return()
 

--- a/man/agepro_inp_model.Rd
+++ b/man/agepro_inp_model.Rd
@@ -148,7 +148,11 @@ Throws a Not Implemented exception message. Placeholder function.
 \subsection{Method \code{write_inp()}}{
 Writes AGEPRO keyword parameter data as a AGEPRO input file (*.inp)
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{agepro_inp_model$write_inp(inpfile, delimiter = "  ", as_currentver = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{agepro_inp_model$write_inp(
+  inpfile,
+  delimiter = "  ",
+  overwrite_as_currentver = TRUE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -158,8 +162,8 @@ Writes AGEPRO keyword parameter data as a AGEPRO input file (*.inp)
 
 \item{\code{delimiter}}{Character string delimiter separating values of AGEPRO input file line.}
 
-\item{\code{as_currentver}}{As default, saves to the current version of the
-AGEPRO input file format.}
+\item{\code{overwrite_as_currentver}}{As default, overwrites version value to
+to the current version of the AGEPRO input file format.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/agepro_model.Rd
+++ b/man/agepro_model.Rd
@@ -80,6 +80,8 @@ calculated across all fleets with the rebuild spawning biomass.}
 mortality (\eqn{M})}
 
 \item{\code{options}}{Options for AGEPRO projection output}
+
+\item{\code{supported_inpfile_versions}}{Supported AGEPRO Input File formats}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
- revert to `AGEPRO VERSION 4.0` as `currentver_inpfile_string` . Input files will be written to `AGEPRO VERSION 4.0`
  - supported_inpfile_versions are: `currentver_inpfile_string`, `AGEPRO VERSION 4.0` , `AGEPRO VERSION 4.25`
  - `write_inp(overwrite_as_currentver = FALSE)` save to AGEPRO Input File and keep the supported version of input file (`AGEPRO VERSION 4.25`)
- `write_inp`: Use **withCallingHandlers** to properly handle errors when retrieving AGEPRO Input File formatted Strings from keyword parameter classes (`get_inp_lines`) 
- rename **agepro_inp_model** private helper function `set_inpfile_version -> write_inpfile_version` 
  - Includes warning if (Supported) AGEPRO Input File Version is not the "current version"
- RoxygenNote Updated
 