### PR TITLE
NULL & Deprecated Model 9 Recruitment Model Data validation for Input Data

### DIFF
--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -1271,8 +1271,10 @@ agepro_inp_model <- R6Class(
     read_pstar_projection = function(con, nline) {
 
       if(self$projection_analyses_type == "rebuild"){
-        stop(paste0("Reading PSTAR projection data but ",
-                    "projection_analyses_type is 'rebuild'"))
+        stop(paste0("Read REBUILD projection data prevents ",
+                    "PSTAR projections to be read from file. ",
+                    "(current projection_analyses_type is 'rebuild')"),
+             call. = FALSE)
       }
 
       self$set_projection_analyses_type("pstar")
@@ -1283,8 +1285,10 @@ agepro_inp_model <- R6Class(
     read_rebuild_projection = function(con, nline) {
 
       if(self$projection_analyses_type == "pstar"){
-        stop(paste0("Reading REBUILD projection data but ",
-                    "projection_analyses_type is 'pstar'"))
+        stop(paste0("Read PSTAR projection data prevents ",
+                    "REBUILD projection data to be read from file. ",
+                    "(current projection_analyses_type is 'pstar')"),
+             call. = FALSE)
       }
 
       self$set_projection_analyses_type("rebuild")

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -1117,7 +1117,7 @@ agepro_inp_model <- R6Class(
 
         },
         error = function(cond) {
-          message("There was an error writing this file. \n", cond)
+
         }
 
       )

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -104,7 +104,7 @@ agepro_model <- R6Class(
                            .var.name = "general")
 
       #Assign and verify projection_analyses_type
-      self$set_projection_analyses_type(projection_analyses_type)
+      self$setup_projection_analyses_values(projection_analyses_type)
 
       private$.discards_present <- x$discards_present
 
@@ -290,34 +290,49 @@ agepro_model <- R6Class(
     #'
     #' @template enable_cat_print
     #'
-    set_projection_analyses_type = function(type,
+    setup_projection_analyses_values = function(type,
                                             enable_cat_print = FALSE) {
 
-      # Check `type` is "standard", "pstar", or "rebuild" and assign to
-      # projection_analyses_type
-      self$projection_analyses_type <- type
+      previous_projection_type <- self$projection_analyses_type
+
       cli::cli_alert_info(paste0("AGEPRO Model Projection analyses type set ",
-                                 "to {.field {self$projection_analyses_type}}"))
+                                 "to {.field {type}}"))
+      tryCatch({
 
-      #Clean PSTAR and REBULD
-      if(isFALSE(is.null(self$pstar)))  {
-        self$pstar <- NULL
-      }
-      if(isFALSE(is.null(self$rebuild))) {
-        self$rebuild <- NULL
-      }
+          #Clean PSTAR and REBULD
+          if(isFALSE(is.null(self$pstar)))  {
+            self$pstar <- NULL
+          }
+          if(isFALSE(is.null(self$rebuild))) {
+            self$rebuild <- NULL
+          }
 
-      if(self$projection_analyses_type == "pstar") {
+          #if(self$projection_analyses_type == "pstar") {
+          if(type == "pstar"){
 
-        cli::cli_alert("Creating default PStar projection values...")
-        self$pstar <- pstar_projection$new(self$general$seq_years)
+            self$pstar <- pstar_projection$new(self$general$seq_years)
+            cli::cli_alert("Default values for PStar projection created.")
 
-      }else if(self$projection_analyses_type == "rebuild") {
+          #}else if(self$projection_analyses_type == "rebuild") {
+          }else if(type =="rebuild") {
 
-        cli::cli_alert("Creating default Rebuild Projection values ...")
-        self$rebuild <- rebuild_projection$new(self$general$seq_years)
+            self$rebuild <- rebuild_projection$new(self$general$seq_years)
+            cli::cli_alert("Default values for Rebuild Projection created.")
 
-      }
+          }
+
+          # projection_analyses_type active binding will verify input value
+          # `type` is "standard", "pstar", or "rebuild" before being assiged
+          self$projection_analyses_type <- type
+
+        },
+        error = function(cond) {
+
+          message(paste0("Revert to previous value: ",
+                         previous_projection_type))
+
+        }
+      )
 
     }
 
@@ -879,7 +894,7 @@ agepro_inp_model <- R6Class(
           #(Re)Set File connection to input file
           inp_con <- file(file.path(inpfile), "r")
 
-          self$set_projection_analyses_type("standard")
+          self$setup_projection_analyses_values("standard")
           self$read_inpfile_values(inp_con)
 
           #Cleanup and close file connections
@@ -1277,7 +1292,7 @@ agepro_inp_model <- R6Class(
              call. = FALSE)
       }
 
-      self$set_projection_analyses_type("pstar")
+      self$setup_projection_analyses_values("pstar")
 
       self$nline <- self$pstar$read_inp_lines(con, nline)
     },
@@ -1291,7 +1306,7 @@ agepro_inp_model <- R6Class(
              call. = FALSE)
       }
 
-      self$set_projection_analyses_type("rebuild")
+      self$setup_projection_analyses_values("rebuild")
 
       self$nline <- self$rebuild$read_inp_lines(con, nline)
     },
@@ -1639,7 +1654,7 @@ agepro_json_model <- R6Class(
           cli::cli_alert_success("Harvest Scenario")
           if(self$projection_analyses_type == "pstar"){
 
-            self$set_projection_analyses_type("pstar")
+            self$setup_projection_analyses_values("pstar")
             cli::cli_alert_info(paste0("Importing PStar Projection values ",
                                        "from AGEPRO Input Data format ..."))
             self$pstar <- inp_model$pstar
@@ -1647,7 +1662,7 @@ agepro_json_model <- R6Class(
           }
           if(self$projection_analyses_type == "rebuild"){
 
-            self$set_projection_analyses_type("rebuild")
+            self$setup_projection_analyses_values("rebuild")
             cli::cli_alert_info(paste0("Importing Rebuling Projection values ",
                                        "from AGEPRO Input Data format ..."))
             self$rebuild <- inp_model$rebuild

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -1345,7 +1345,7 @@ agepro_inp_model <- R6Class(
 
       # Throw Warning if (supported) VERSION string doesn't match
       # "current version" AGEPRO Input file format
-      if(isFALSE(identical(self$ver_inpfile_string,
+      if(isFALSE(identical(inp_line,
                     private$.currentver_inpfile_string))){
         warning(paste0(inp_line,
                        " (Line 1 read from input file),",

--- a/R/recruit_model.R
+++ b/R/recruit_model.R
@@ -139,7 +139,7 @@ null_recruit_model <- R6Class(
     #' NuLL recruitment
     #'
     inp_lines_recruit_data = function(delimiter= " ") {
-      stop("Found invalid NULL Recruruitment recruitment model data.",
+      stop("NULL Recruitment model is invalid for AGEPRO input.",
           call. = FALSE)
     }
 

--- a/R/recruit_model.R
+++ b/R/recruit_model.R
@@ -101,8 +101,12 @@ recruit_model <- R6Class(
 
 
 #' Null Recruitment UI Fallback Default
+#'
 #' @inherit recruit_model description
+#'
 #' @template elipses
+#' @template delimiter
+#'
 #' @export
 null_recruit_model <- R6Class(
   "null_recruit_model",
@@ -126,7 +130,19 @@ null_recruit_model <- R6Class(
       cli_text("{private$.model_name}")
       cli_alert_warning(c("Replace with a valid recruitment model before ",
                           "processing to AGEPRO calcualtion engine"))
+    },
+
+    #' @description
+    #' Function container to export recruitment model data to AGEPRO input model
+    #' file lines, but since NULL recruitment is not a valid recruitment model
+    #' type for the AGEPRO calculation engine, an error will thrown to indicate
+    #' NuLL recruitment
+    #'
+    inp_lines_recruit_data = function(delimiter= " ") {
+      stop("Found invalid NULL Recruruitment recruitment model data.",
+          call. = FALSE)
     }
+
   )
 )
 
@@ -136,6 +152,7 @@ null_recruit_model <- R6Class(
 #' Handles an instance for deprecated recruitment model #9.
 #'
 #' @template elipses
+#' @template delimiter
 #' @export
 #'
 deprecated_recruit_model_9 <- R6Class(
@@ -162,7 +179,20 @@ deprecated_recruit_model_9 <- R6Class(
                               "Time-Varying Empirical Distribution."),
            call. = FALSE)
 
+    },
+
+    #' @description
+    #' Function container to export recruitment model data to AGEPRO input model
+    #' file lines, but since this model is DEPRECATED; not a valid recruitment
+    #' model type for the AGEPRO calculation engine, an error will thrown.
+    #'
+    inp_lines_recruit_data = function(delimiter= " ") {
+      stop(paste0("Recruitment Model #9 is DEPRECATED. ",
+                  "Please use the Empirical Recruitment Distribution Model ",
+                  "(#3) with Time-Variance."),
+           call. = FALSE)
     }
+
 
   ),
   private = list(

--- a/R/recruit_model.R
+++ b/R/recruit_model.R
@@ -174,10 +174,7 @@ deprecated_recruit_model_9 <- R6Class(
     #' Prints out the error
     print = function(...) {
       private$cli_recruit_danger()
-      stop(paste0("Recruitment model #9 has been deperecated. ",
-                              "Please use recruitment model #3 to implement ",
-                              "Time-Varying Empirical Distribution."),
-           call. = FALSE)
+      stop(private$.err_model_deprecated, call. = FALSE)
 
     },
 
@@ -187,15 +184,16 @@ deprecated_recruit_model_9 <- R6Class(
     #' model type for the AGEPRO calculation engine, an error will thrown.
     #'
     inp_lines_recruit_data = function(delimiter= " ") {
-      stop(paste0("Recruitment Model #9 is DEPRECATED. ",
-                  "Please use the Empirical Recruitment Distribution Model ",
-                  "(#3) with Time-Variance."),
-           call. = FALSE)
+      stop(private$.err_model_deprecated, call. = FALSE)
     }
-
 
   ),
   private = list(
+
+    .err_model_deprecated =
+      paste0("Recruitment Model #9 is DEPRECATED",
+             "Please use the Empirical Recruitment Distribution Model ",
+             "(#3) with Time-Variance."),
 
     cli_recruit_danger = function() {
       d <- cli_div(class = "tmp", theme = list(.tmp = list(

--- a/R/recruit_model.R
+++ b/R/recruit_model.R
@@ -143,6 +143,18 @@ null_recruit_model <- R6Class(
           call. = FALSE)
     }
 
+  ),
+  active = list(
+
+    #' @field json_recruit_data
+    #' Function container to export recruitment model data to experimental
+    #' jSon input model file. However, NULL recruitment is not a
+    #' valid recruitment model type, an error will thrown.
+    json_recruit_data = function() {
+      stop("NULL Recruitment model data is invalid JSON data.",
+           call. = FALSE)
+    }
+
   )
 )
 
@@ -184,6 +196,17 @@ deprecated_recruit_model_9 <- R6Class(
     #' model type for the AGEPRO calculation engine, an error will thrown.
     #'
     inp_lines_recruit_data = function(delimiter= " ") {
+      stop(private$.err_model_deprecated, call. = FALSE)
+    }
+
+  ),
+  active = list(
+
+    #' @field json_recruit_data
+    #' Function container to export recruitment model data to experimental
+    #' jSon input model file. Because recruitment model #9 is DEPRECATED, and
+    #' not used in the AGEPRO calculation engine, an error will thrown.
+    json_recruit_data = function() {
       stop(private$.err_model_deprecated, call. = FALSE)
     }
 

--- a/R/recruitment.R
+++ b/R/recruitment.R
@@ -409,6 +409,17 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
     #'
     json_list_object = function() {
 
+    recruit_json_list_object <- list(
+      recFac = self$recruit_scaling_factor,
+      ssbFac = self$ssb_scaling_factor,
+      maxRecObs = private$.max_recruit_obs,
+      #list of model numbers
+      type = unlist(self$recruit_model_num_list),
+      prob = self$recruit_probability
+    )
+
+    #recruitData
+
     tryCatch({
         #Gather Recruit Model Data
         recruit_model_data_list <-
@@ -419,19 +430,20 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
             self$recruit_data[[recruit]][["json_recruit_data"]]
         }
 
-        return(list(
-          recFac = self$recruit_scaling_factor,
-          ssbFac = self$ssb_scaling_factor,
-          maxRecObs = private$.max_recruit_obs,
-          #list of model numbers
-          type = unlist(self$recruit_model_num_list),
-          prob = self$recruit_probability,
+        return(c(
+          recruit_json_list_object,
           recruitData = recruit_model_data_list))
-
 
       },
       error = function(cond) {
 
+        message(paste0("Invalid Recruitment Model or model data Found, ",
+                       "returning NULL recruitData."))
+        #Nullify for JSON output
+        return(c(
+          recruit_json_list_object,
+          recruitData = list(NULL)
+        ))
       }
     )
 

--- a/R/recruitment.R
+++ b/R/recruitment.R
@@ -409,23 +409,31 @@ recruitment <- R6Class( # nolint: cyclocomp_linter
     #'
     json_list_object = function() {
 
-      #Gather Recruit Model Data
-      recruit_model_data_list <-
-        vector("list", length(self$recruit_model_num_list))
+    tryCatch({
+        #Gather Recruit Model Data
+        recruit_model_data_list <-
+          vector("list", length(self$recruit_model_num_list))
 
-      for (recruit in seq_along(self$recruit_model_num_list)){
-        recruit_model_data_list[[recruit]] <-
-          self$recruit_data[[recruit]][["json_recruit_data"]]
+        for (recruit in seq_along(self$recruit_model_num_list)){
+          recruit_model_data_list[[recruit]] <-
+            self$recruit_data[[recruit]][["json_recruit_data"]]
+        }
+
+        return(list(
+          recFac = self$recruit_scaling_factor,
+          ssbFac = self$ssb_scaling_factor,
+          maxRecObs = private$.max_recruit_obs,
+          #list of model numbers
+          type = unlist(self$recruit_model_num_list),
+          prob = self$recruit_probability,
+          recruitData = recruit_model_data_list))
+
+
+      },
+      error = function(cond) {
+
       }
-
-      return(list(
-        recFac = self$recruit_scaling_factor,
-        ssbFac = self$ssb_scaling_factor,
-        maxRecObs = private$.max_recruit_obs,
-        #list of model numbers
-        type = unlist(self$recruit_model_num_list),
-        prob = self$recruit_probability,
-        recruitData = recruit_model_data_list))
+    )
 
     },
 

--- a/man/agepro_inp_model.Rd
+++ b/man/agepro_inp_model.Rd
@@ -38,8 +38,8 @@ File Functionality is based on AGEPRO-CoreLib implementation
 <ul>
 <li><span class="pkg-link" data-pkg="ageproR" data-topic="agepro_model" data-id="default_agepro_keyword_params"><a href='../../ageproR/html/agepro_model.html#method-agepro_model-default_agepro_keyword_params'><code>ageproR::agepro_model$default_agepro_keyword_params()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="ageproR" data-topic="agepro_model" data-id="set_bootstrap_filename"><a href='../../ageproR/html/agepro_model.html#method-agepro_model-set_bootstrap_filename'><code>ageproR::agepro_model$set_bootstrap_filename()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="ageproR" data-topic="agepro_model" data-id="set_projection_analyses_type"><a href='../../ageproR/html/agepro_model.html#method-agepro_model-set_projection_analyses_type'><code>ageproR::agepro_model$set_projection_analyses_type()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="ageproR" data-topic="agepro_model" data-id="set_recruit_model"><a href='../../ageproR/html/agepro_model.html#method-agepro_model-set_recruit_model'><code>ageproR::agepro_model$set_recruit_model()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="ageproR" data-topic="agepro_model" data-id="setup_projection_analyses_values"><a href='../../ageproR/html/agepro_model.html#method-agepro_model-setup_projection_analyses_values'><code>ageproR::agepro_model$setup_projection_analyses_values()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/agepro_json_model.Rd
+++ b/man/agepro_json_model.Rd
@@ -25,8 +25,8 @@ File Functionality on experimental JSON input file
 <ul>
 <li><span class="pkg-link" data-pkg="ageproR" data-topic="agepro_model" data-id="default_agepro_keyword_params"><a href='../../ageproR/html/agepro_model.html#method-agepro_model-default_agepro_keyword_params'><code>ageproR::agepro_model$default_agepro_keyword_params()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="ageproR" data-topic="agepro_model" data-id="set_bootstrap_filename"><a href='../../ageproR/html/agepro_model.html#method-agepro_model-set_bootstrap_filename'><code>ageproR::agepro_model$set_bootstrap_filename()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="ageproR" data-topic="agepro_model" data-id="set_projection_analyses_type"><a href='../../ageproR/html/agepro_model.html#method-agepro_model-set_projection_analyses_type'><code>ageproR::agepro_model$set_projection_analyses_type()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="ageproR" data-topic="agepro_model" data-id="set_recruit_model"><a href='../../ageproR/html/agepro_model.html#method-agepro_model-set_recruit_model'><code>ageproR::agepro_model$set_recruit_model()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="ageproR" data-topic="agepro_model" data-id="setup_projection_analyses_values"><a href='../../ageproR/html/agepro_model.html#method-agepro_model-setup_projection_analyses_values'><code>ageproR::agepro_model$setup_projection_analyses_values()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/agepro_model.Rd
+++ b/man/agepro_model.Rd
@@ -92,7 +92,7 @@ mortality (\eqn{M})}
 \item \href{#method-agepro_model-default_agepro_keyword_params}{\code{agepro_model$default_agepro_keyword_params()}}
 \item \href{#method-agepro_model-set_recruit_model}{\code{agepro_model$set_recruit_model()}}
 \item \href{#method-agepro_model-set_bootstrap_filename}{\code{agepro_model$set_bootstrap_filename()}}
-\item \href{#method-agepro_model-set_projection_analyses_type}{\code{agepro_model$set_projection_analyses_type()}}
+\item \href{#method-agepro_model-setup_projection_analyses_values}{\code{agepro_model$setup_projection_analyses_values()}}
 \item \href{#method-agepro_model-clone}{\code{agepro_model$clone()}}
 }
 }
@@ -215,9 +215,9 @@ Wrapper function to call bootstrap's set_bootstrap_filename
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-agepro_model-set_projection_analyses_type"></a>}}
-\if{latex}{\out{\hypertarget{method-agepro_model-set_projection_analyses_type}{}}}
-\subsection{Method \code{set_projection_analyses_type()}}{
+\if{html}{\out{<a id="method-agepro_model-setup_projection_analyses_values"></a>}}
+\if{latex}{\out{\hypertarget{method-agepro_model-setup_projection_analyses_values}{}}}
+\subsection{Method \code{setup_projection_analyses_values()}}{
 Helper Function to setup agepro model's projection analyses type. agepro
 models use standard projection analyses by default, and do not require
 additional keyword parameter setup. "pstar" and  "rebuild" projection
@@ -227,7 +227,7 @@ However, they are not created during model initialization.
 AGEPRO models must can not have both pstar and rebuilder projection
 analyses,
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{agepro_model$set_projection_analyses_type(type, enable_cat_print = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{agepro_model$setup_projection_analyses_values(type, enable_cat_print = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/deprecated_recruit_model_9.Rd
+++ b/man/deprecated_recruit_model_9.Rd
@@ -22,6 +22,7 @@ Handles an instance for deprecated recruitment model #9.
 \itemize{
 \item \href{#method-deprecated_recruit_model_9-new}{\code{deprecated_recruit_model_9$new()}}
 \item \href{#method-deprecated_recruit_model_9-print}{\code{deprecated_recruit_model_9$print()}}
+\item \href{#method-deprecated_recruit_model_9-inp_lines_recruit_data}{\code{deprecated_recruit_model_9$inp_lines_recruit_data()}}
 \item \href{#method-deprecated_recruit_model_9-clone}{\code{deprecated_recruit_model_9$clone()}}
 }
 }
@@ -48,6 +49,25 @@ Prints out the error
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{...}}{further arguments passed to or from other methods}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-deprecated_recruit_model_9-inp_lines_recruit_data"></a>}}
+\if{latex}{\out{\hypertarget{method-deprecated_recruit_model_9-inp_lines_recruit_data}{}}}
+\subsection{Method \code{inp_lines_recruit_data()}}{
+Function container to export recruitment model data to AGEPRO input model
+file lines, but since this model is DEPRECATED; not a valid recruitment
+model type for the AGEPRO calculation engine, an error will thrown.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{deprecated_recruit_model_9$inp_lines_recruit_data(delimiter = " ")}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{delimiter}}{Character string delimiter separating values of AGEPRO input file line.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/deprecated_recruit_model_9.Rd
+++ b/man/deprecated_recruit_model_9.Rd
@@ -17,6 +17,15 @@ Handles an instance for deprecated recruitment model #9.
 \section{Super class}{
 \code{\link[ageproR:recruit_model]{ageproR::recruit_model}} -> \code{deprecated_recruit_model_9}
 }
+\section{Active bindings}{
+\if{html}{\out{<div class="r6-active-bindings">}}
+\describe{
+\item{\code{json_recruit_data}}{Function container to export recruitment model data to experimental
+jSon input model file. Because recruitment model #9 is DEPRECATED, and
+not used in the AGEPRO calculation engine, an error will thrown.}
+}
+\if{html}{\out{</div>}}
+}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{

--- a/man/null_recruit_model.Rd
+++ b/man/null_recruit_model.Rd
@@ -14,6 +14,7 @@ Recruitment Model Description
 \itemize{
 \item \href{#method-null_recruit_model-new}{\code{null_recruit_model$new()}}
 \item \href{#method-null_recruit_model-print}{\code{null_recruit_model$print()}}
+\item \href{#method-null_recruit_model-inp_lines_recruit_data}{\code{null_recruit_model$inp_lines_recruit_data()}}
 \item \href{#method-null_recruit_model-clone}{\code{null_recruit_model$clone()}}
 }
 }
@@ -40,6 +41,26 @@ Prints out NULL Recruiment Model Data
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{...}}{further arguments passed to or from other methods}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-null_recruit_model-inp_lines_recruit_data"></a>}}
+\if{latex}{\out{\hypertarget{method-null_recruit_model-inp_lines_recruit_data}{}}}
+\subsection{Method \code{inp_lines_recruit_data()}}{
+Function container to export recruitment model data to AGEPRO input model
+file lines, but since NULL recruitment is not a valid recruitment model
+type for the AGEPRO calculation engine, an error will thrown to indicate
+NuLL recruitment
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{null_recruit_model$inp_lines_recruit_data(delimiter = " ")}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{delimiter}}{Character string delimiter separating values of AGEPRO input file line.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/null_recruit_model.Rd
+++ b/man/null_recruit_model.Rd
@@ -9,6 +9,15 @@ Recruitment Model Description
 \section{Super class}{
 \code{\link[ageproR:recruit_model]{ageproR::recruit_model}} -> \code{null_recruit_model}
 }
+\section{Active bindings}{
+\if{html}{\out{<div class="r6-active-bindings">}}
+\describe{
+\item{\code{json_recruit_data}}{Function container to export recruitment model data to experimental
+jSon input model file. However, NULL recruitment is not a
+valid recruitment model type, an error will thrown.}
+}
+\if{html}{\out{</div>}}
+}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{


### PR DESCRIPTION
This Resolves #54 

- Use version string (line 1) from AGEPRO Input File to correctly check for "current version"
- Validation checks for Invalid recruitment model data from NULL or Deprecated Recruitment model 9, when importing and exporting to AGEPRO Input File and JSON Input file 
  - Interrupts export to AGEPRO Input File, if invalid recruitment model data found.
  - JSON input file: Nullify `recruitData` , if invalid recruitment model data found. 
- rename `set_projection_analyses -> setup_projection_analyses_value`
  - Function now checks input 'type' parameter value before assigning to projection_analyses_type
- Error message clarifications 