### PR TITLE
Fix 64

### DIFF
--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -852,8 +852,7 @@ agepro_inp_model <- R6Class(
     #' @template model_general_params
     #' @param enable_cat_print
     #' Logical flag to show target function's **cli** [`cat_print`][cli::cat_print]
-    #' messages to be seen on console. In this instance, this is set to FALSE.
-    #'
+    #' messages to be seen on console. In this instance, this is set to TRUE
     #'
     initialize = function(yr_start = 0,
                           yr_end = 2,
@@ -864,12 +863,20 @@ agepro_inp_model <- R6Class(
                           num_rec_models = 1,
                           discards_present = 0,
                           seed =  sample.int(1e8, 1),
-                          enable_cat_print = FALSE) {
+                          enable_cat_print = TRUE) {
 
-      # private$.nline <- 0
-      # private$setup_ver_rpackage()
 
-      cli::cli_alert("Setting up defualt AGEPRO model w/ default values")
+      if(all(isTRUE(c(
+        missing(yr_start),
+        missing(yr_end),
+        missing(age_begin),
+        missing(age_end),
+        missing(num_pop_sims),
+        missing(num_fleets),
+        missing(num_rec_models)
+      )))){
+        cli::cli_alert("Setting up defualt AGEPRO model w/ default values")
+      }
 
       super$initialize(yr_start,
                        yr_end,
@@ -882,21 +889,6 @@ agepro_inp_model <- R6Class(
                        seed,
                        enable_cat_print = enable_cat_print)
 
-#
-#       if(isFALSE(enable_cat_print)) {
-#         self$general <- suppressMessages(general_params$new())
-#
-#         suppressMessages(
-#           self$default_agepro_keyword_params(self$general,
-#                                              enable_cat_print =
-#                                                enable_cat_print))
-#       } else {
-#         self$general <- general_params$new()
-#         self$default_agepro_keyword_params(self$general,
-#                                            enable_cat_print = TRUE)
-#       }
-#
-#       cli::cli_text("Done")
     },
 
     #' @description

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -116,7 +116,7 @@ agepro_model <- R6Class(
 
       private$.discards_present <- x$discards_present
 
-      self$case_id <- case_id$new()
+      self$case_id <- case_id$new("Unnamed AGEPRO model")
 
       #TODO: rename cat_verbose to enable_cat_print
       self$recruit <- recruitment$new(rep(0, x$num_rec_models),

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -836,9 +836,11 @@ agepro_inp_model <- R6Class(
   public = list(
 
     #' @description
-    #' Initializes an instance of the AGEPRO model with default blank keyword
-    #' parameter values, by using the default
-    #' [general_params][ageproR::general_params] values:
+    #' Initializes an instance of the AGEPRO model with AGEPRO input file
+    #' format functions. A default model can be initialized without setting
+    #' [general_params][ageproR::general_params] parameter values. The default
+    #' values for the default model is:
+    #'
     #' \itemize{
     #'  \item Projection years: From `yr_start` 0 to `yr_end` 2
     #'  \item Ages: From `age_begin` 1 to `age_end` 6

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -28,15 +28,11 @@ agepro_model <- R6Class(
     #' @description
     #' Initializes the instance of the AGEPRO Model
     #'
-    #' @param yr_start First Year of Projection
-    #' @param yr_end Last Year of Projection
-    #' @param age_begin Age begin
-    #' @param age_end Age end
-    #' @param num_pop_sims Number of population simulations
-    #' @param num_fleets Number of fleets
-    #' @param num_rec_models Number of Recruit Modules
-    #' @param discards_present Are Discards present? FALSE by default
-    #' @param seed Random Number seed. A pesdorandom number is set as default.
+    #' @template model_general_params
+    #' @param enable_cat_print
+    #' Logical flag to show target function's **cli**
+    #' [`cat_print`][cli::cat_print] messages to be seen on console. By default,
+    #' this is set to TRUE.
     #'
     initialize = function(yr_start,
                            yr_end,
@@ -46,7 +42,8 @@ agepro_model <- R6Class(
                            num_fleets,
                            num_rec_models,
                            discards_present = FALSE,
-                           seed = sample.int(1e8, 1)) {
+                           seed = sample.int(1e8, 1),
+                          enable_cat_print = TRUE) {
 
       #Current Input File Version
       private$.ver_inpfile_string = private$.currentver_inpfile_string
@@ -60,17 +57,28 @@ agepro_model <- R6Class(
 
       #Set GENERAL
       self$general <- general_params$new(yr_start,
-                                        yr_end,
-                                        age_begin,
-                                        age_end,
-                                        num_pop_sims,
-                                        num_fleets,
-                                        num_rec_models,
-                                        discards_present,
-                                        seed)
+                                         yr_end,
+                                         age_begin,
+                                         age_end,
+                                         num_pop_sims,
+                                         num_fleets,
+                                         num_rec_models,
+                                         discards_present,
+                                         seed,
+                                         enable_cat_print = enable_cat_print)
 
       ## Helper function to create a new instance of agepro_model
-      self$default_agepro_keyword_params(self$general)
+      if(enable_cat_print){
+
+        self$default_agepro_keyword_params(self$general,
+                                           enable_cat_print = enable_cat_print)
+      }else{
+
+        suppressMessages(
+          self$default_agepro_keyword_params(self$general,
+                                           enable_cat_print = enable_cat_print))
+      }
+
 
       cli::cli_alert_success("Done")
     },
@@ -841,33 +849,54 @@ agepro_inp_model <- R6Class(
     #'  \item Pseudo-Randomly generated `seed`
     #' }
     #'
+    #' @template model_general_params
     #' @param enable_cat_print
     #' Logical flag to show target function's **cli** [`cat_print`][cli::cat_print]
     #' messages to be seen on console. In this instance, this is set to FALSE.
     #'
     #'
-    initialize = function(enable_cat_print = FALSE) {
+    initialize = function(yr_start = 0,
+                          yr_end = 2,
+                          age_begin = 1,
+                          age_end = 6,
+                          num_pop_sims = 1000,
+                          num_fleets = 1,
+                          num_rec_models = 1,
+                          discards_present = 0,
+                          seed =  sample.int(1e8, 1),
+                          enable_cat_print = FALSE) {
 
-      private$.nline <- 0
-      private$setup_ver_rpackage()
+      # private$.nline <- 0
+      # private$setup_ver_rpackage()
 
       cli::cli_alert("Setting up defualt AGEPRO model w/ default values")
 
+      super$initialize(yr_start,
+                       yr_end,
+                       age_begin,
+                       age_end,
+                       num_pop_sims,
+                       num_fleets,
+                       num_rec_models,
+                       discards_present,
+                       seed,
+                       enable_cat_print = enable_cat_print)
 
-      if(isFALSE(enable_cat_print)) {
-        self$general <- suppressMessages(general_params$new())
-
-        suppressMessages(
-          self$default_agepro_keyword_params(self$general,
-                                             enable_cat_print =
-                                               enable_cat_print))
-      } else {
-        self$general <- general_params$new()
-        self$default_agepro_keyword_params(self$general,
-                                           enable_cat_print = TRUE)
-      }
-
-      cli::cli_text("Done")
+#
+#       if(isFALSE(enable_cat_print)) {
+#         self$general <- suppressMessages(general_params$new())
+#
+#         suppressMessages(
+#           self$default_agepro_keyword_params(self$general,
+#                                              enable_cat_print =
+#                                                enable_cat_print))
+#       } else {
+#         self$general <- general_params$new()
+#         self$default_agepro_keyword_params(self$general,
+#                                            enable_cat_print = TRUE)
+#       }
+#
+#       cli::cli_text("Done")
     },
 
     #' @description

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -114,11 +114,9 @@ bootstrap <- R6Class(
       cli_li(paste0("pop_scale_factor (BootFac): ",
                "{.val {self$pop_scale_factor}}"))
       cli_alert_info("bootstrap_file:")
-      ifelse(test_file_exists(self$bootstrap_file),
-             cli_li("{.val {self$bootstrap_file}}"),
-             cli_alert_warning(c("Replace with a valid Bootstrap file before ",
-                            "processing to AGEPRO calcualtion engine"))
-             )
+
+      private$validate_bootstrap_file(self$bootstrap)
+
       cli_end()
     }
 
@@ -206,7 +204,7 @@ bootstrap <- R6Class(
 
       }else if (is.null(value)) {
         #Warn if file path is NULL,
-        warning(paste0("NULL Bootstrap file path. \n",
+        warning(paste0("NULL Bootstrap file path. ",
                        "Please provide a vaild bootstrap filepath when saving ",
                        "to input file for the AGEPRO calcuation engine."),
                 call. = FALSE)

--- a/R/case_id.R
+++ b/R/case_id.R
@@ -17,8 +17,10 @@ case_id <- R6Class(
     #' @description
     #' Initialize Class
     #'
-    initalize = function() {
-      self$model_name <- NULL
+    #' @param model_name Character string that describes the projection model
+    #'
+    initialize = function(model_name = NULL) {
+      self$model_name <- model_name
     },
 
     #' @description

--- a/R/general_params.R
+++ b/R/general_params.R
@@ -31,6 +31,9 @@ general_params <- R6Class(
     #' @param num_rec_models Number of Recruit Modeles
     #' @param discards_present discards_present
     #' @param seed Random Number seed
+    #' @param enable_cat_print
+    #' Logical flag to show target function's messages on console.
+    #' By Default, set to TRUE.
     #'
     initialize = function(yr_start = 0,
                           yr_end = 2,
@@ -40,10 +43,13 @@ general_params <- R6Class(
                           num_fleets = 1,
                           num_rec_models = 1,
                           discards_present = FALSE,
-                          seed = sample.int(1e8, 1)) {
+                          seed = sample.int(1e8, 1),
+                          enable_cat_print = TRUE) {
 
 
-      div_keyword_header(self$keyword_name)
+      if(enable_cat_print){
+        div_keyword_header(self$keyword_name)
+      }
       # Discards: Assert numeric format
       if (test_logical(discards_present)) {
         discards_present <- as.numeric(discards_present)
@@ -59,8 +65,9 @@ general_params <- R6Class(
       private$set_discards_present(discards_present)
       private$set_seed(as.numeric(seed))
 
-      self$print()
-
+      if(enable_cat_print){
+        self$print()
+      }
 
     },
 

--- a/R/max_bounds.R
+++ b/R/max_bounds.R
@@ -255,10 +255,13 @@ max_bounds <- R6Class(
     .max_weight = NULL,
     .max_natural_mortality = NULL,
 
+    .name_options_flag = "enable_max_bounds",
+
     reset_options_flags = function() {
       #Reset option_flag to NULL at initialization
       if(isFALSE(is.null(self$flag$op$enable_max_bounds))){
-        cli::cli_alert("Reset enable_max_bounds")
+        cli::cli_alert(paste0("Reset {private$.name_options_flag} ",
+                              "for initialization"))
         self$flag$op$enable_max_bounds <- NULL
         }
     }

--- a/R/recruit_model.R
+++ b/R/recruit_model.R
@@ -127,9 +127,13 @@ null_recruit_model <- R6Class(
     #' @description
     #' Prints out NULL Recruiment Model Data
     print = function(...) {
+      warn_null_recruit <-
+        paste0("NULL Recrumitment model found. ",
+               "Replace with a valid recruitment model before ",
+               "saving to input file")
       cli_text("{private$.model_name}")
-      cli_alert_warning(c("Replace with a valid recruitment model before ",
-                          "processing to AGEPRO calcualtion engine"))
+
+      warning(warn_null_recruit, call. = FALSE)
     },
 
     #' @description

--- a/R/reference_points.R
+++ b/R/reference_points.R
@@ -70,11 +70,11 @@ reference_points <- R6Class(
                all.equal(meanbio_threshold, 0),
                all.equal(fmort_threshold,0))))  {
         cli::cli_alert(paste0("Default values set, ",
-                              "options_flag enable_refernce_points to FALSE"))
+                              "options_flag {private$.name_options_flag} to FALSE"))
         suppressMessages(private$set_enable_reference_points(FALSE))
       }else{
         cli::cli_alert(paste0("Values for reference_points set. ",
-                              "Enable options_flag enable_reference_points ",
+                              "Enable options_flag {private$.name_options_flag} ",
                               "as TRUE"))
         private$set_enable_reference_points(TRUE)
         self$print()
@@ -322,6 +322,8 @@ reference_points <- R6Class(
     .mean_biomass_threshold = NULL,
     .fishing_mortality_threshold = NULL,
 
+    .name_options_flag = "enable_reference_points",
+
     # Wrapper Function to toggle enable_reference_points options_flag.
     set_enable_reference_points = function(x) {
 
@@ -331,7 +333,7 @@ reference_points <- R6Class(
       self$flag$op$enable_reference_points <- x
 
       cli::cli_alert(
-        paste0("enable_reference_points : ",
+        paste0("{private$.name_options_flag} : ",
                "{.val ",
                "{self$flag$op$enable_reference_points}}"))
 
@@ -342,7 +344,7 @@ reference_points <- R6Class(
     # enable_reference_points is FALSE
     unenabled_options_flag_message = function() {
       return(invisible(
-        paste0("enable_reference_points is FALSE. ",
+        paste0("{private$.name_options.flag} is FALSE. ",
                   "Set flag to TRUE to set value.")
         ))
     },
@@ -351,7 +353,8 @@ reference_points <- R6Class(
     reset_options_flags = function() {
       #Reset option_flag to NULL at initialization
       if(isFALSE(is.null(self$flag$op$enable_reference_points))){
-        cli::cli_alert("Reset enable_reference_points")
+        cli::cli_alert(paste0("Reset {private$.name_options_flag} ",
+                              "for initialization"))
         self$flag$op$enable_reference_points <- NULL
       }
     }

--- a/R/retrospective_adjustments.R
+++ b/R/retrospective_adjustments.R
@@ -243,7 +243,8 @@ retrospective_adjustments <- R6Class(
       #Reset option_flag to NULL at initialization
 
       if(isFALSE(is.null(self$flag$op[[private$.name_options_flag]]))){
-        cli::cli_alert("Reset {private$.name_option_flag}")
+        cli::cli_alert(paste0("Reset {private$.name_options_flag} ",
+                              "for initalization"))
         self$flag$op[[private$.name_options_flag]] <- NULL
       }
     },

--- a/R/user_percentile_summary.R
+++ b/R/user_percentile_summary.R
@@ -48,7 +48,7 @@ user_percentile_summary <- R6Class(
       # Presume default if perc is 0.
       if(isTRUE(all.equal(perc,0))){
         cli::cli_alert(paste0("Set default values. ",
-                              "options_flag enable_user_percentile_summary ",
+                              "options_flag {private$.name_options_flag} ",
                               "to FALSE"))
         self$report_percentile <- perc
 
@@ -60,7 +60,7 @@ user_percentile_summary <- R6Class(
 
       cli::cli_alert(paste0("Setting for user_percentile_summary values ",
                             "Enable options_flag ",
-                            "enable_user_percentile_summary as TRUE"))
+                            "{private$.name_options_flag} as TRUE"))
       cli::cli_alert("Set report_percentile to {.val {perc}} ..")
 
       self$report_percentile <- perc
@@ -100,7 +100,7 @@ user_percentile_summary <- R6Class(
       self$flag$op$enable_user_percentile_summary <- x
 
       cli::cli_alert(
-        paste0("enable_user_pecentile_summary : ",
+        paste0("{private$.name_options_flag} : ",
                "{.val ",
                "{self$flag$op$enable_user_percentile_summary}}"))
 
@@ -172,7 +172,7 @@ user_percentile_summary <- R6Class(
         checkmate::assert_numeric(value, null.ok = TRUE, len = 1,
                                   lower = 0, upper = 100)
         if(isFALSE(self$flag$op$enable_user_percentile_summary)) {
-          stop(paste0("enable_user_percentile_summary flag is FALSE. ",
+          stop(paste0("{private$.name_options_flag} flag is FALSE. ",
                         "Set flag to TRUE to set value.") )
         }
 
@@ -223,10 +223,13 @@ user_percentile_summary <- R6Class(
 
     .report_percentile = NULL,
 
+    .name_options_flag = "enable_user_percentile_summary",
+
     reset_options_flags = function() {
       #Reset option_flag to NULL at initialization
       if(isFALSE(is.null(self$flag$op$enable_user_percentile_summary))){
-        cli::cli_alert("Set enable_user_percentile_summary to FALSE")
+        cli::cli_alert(paste0("Reset {private$.name_options_flag}",
+                              "for initialization"))
         self$flag$op$enable_user_percentile_summary <- NULL
       }
     }

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,8 +21,18 @@ knitr::opts_chunk$set(
 ageproR is a R-package designed to handle input data to and from Jon Brodizak's 
 AGEPRO (Age Structured Projection Model). 
 
-_**ageproR** is still in early development. Code base may change without warning 
-prior to first stable release._
+## Note
+
+**ageproR** is still in development. These features will be implemented in future updates. 
+
+- Predictor Recruitment Models 
+- Autocorrelated Lognormals Recruitment Models 
+- Fixed Recruitment Model 
+- Empirical Per SSB
+- Empirical Culumative Distrubutuion Fact for w/ Linear Decilne to Zero
+- Markov Matrix Recruitment Model
+- Run AGEPRO models to AGEPRO calcuation engine.
+
 
 **If you using AGEPRO for production, please use:**
 
@@ -36,7 +46,6 @@ You can install the development version of ageproR from
 with:
 
 ```{r, eval = FALSE}
-
 install.packages("remotes")
 remotes::install_github("PIFSCstockassessments/ageproR")
 
@@ -45,15 +54,17 @@ install.packages("pak")
 pak::pkg_install("PIFSCstockassessments/ageproR")
 ```
 
-## AGEPRO input file 
+## AGEPRO input file format
 
-_Note: **ageproR** is currently incompatible with the supported AGEPRO input 
-file format_ (`AGEPRO VERSION 4.0` & `AGEPRO VERSION 4.2`). _Included example 
-AGEPRO input file_ (`inst/test-example4.inp`) _is used to demonstrate it's 
-implemented features._
+**ageproR** is compatible with the AGEPRO input file formats 
+`AGEPRO VERSION 4.0` & `AGEPRO VERSION 4.25`. By default, **ageproR** writes
+to the `AGEPRO VERSION 4.0` Input File Format.
+
+The Included example AGEPRO input file (`inst/test-example4.inp`) is used to 
+demonstrate it's implemented features.
 
 
-## Vignettes
+## Documentation 
 
 Hawaiian Uku Projection Projection base example (TODO)
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,18 @@
 ageproR is a R-package designed to handle input data to and from Jon
 Brodizak’s AGEPRO (Age Structured Projection Model).
 
-***ageproR** is still in early development. Code base may change without
-warning prior to first stable release.*
+## Note
+
+**ageproR** is still in development. These features will be implemented
+in future updates.
+
+- Predictor Recruitment Models
+- Autocorrelated Lognormals Recruitment Models
+- Fixed Recruitment Model
+- Empirical Per SSB
+- Empirical Culumative Distrubutuion Fact for w/ Linear Decilne to Zero
+- Markov Matrix Recruitment Model
+- Run AGEPRO models to AGEPRO calcuation engine.
 
 **If you using AGEPRO for production, please use:**
 
@@ -26,7 +36,6 @@ You can install the development version of ageproR from
 Repository](https://github.com/PIFSCstockassessments/ageproR) with:
 
 ``` r
-
 install.packages("remotes")
 remotes::install_github("PIFSCstockassessments/ageproR")
 
@@ -35,14 +44,16 @@ install.packages("pak")
 pak::pkg_install("PIFSCstockassessments/ageproR")
 ```
 
-## AGEPRO input file
+## AGEPRO input file format
 
-*Note: **ageproR** is currently incompatible with the supported AGEPRO
-input file format* (`AGEPRO VERSION 4.0` & `AGEPRO VERSION 4.2`).
-*Included example AGEPRO input file* (`inst/test-example4.inp`) *is used
-to demonstrate it’s implemented features.*
+**ageproR** is compatible with the AGEPRO input file formats
+`AGEPRO VERSION 4.0` & `AGEPRO VERSION 4.25`. By default, **ageproR**
+writes to the `AGEPRO VERSION 4.0` Input File Format.
 
-## Vignettes
+The Included example AGEPRO input file (`inst/test-example4.inp`) is
+used to demonstrate it’s implemented features.
+
+## Documentation
 
 Hawaiian Uku Projection Projection base example (TODO)
 

--- a/man-roxygen/model_general_params.R
+++ b/man-roxygen/model_general_params.R
@@ -1,0 +1,9 @@
+#' @param yr_start First Year of Projection
+#' @param yr_end Last Year of Projection
+#' @param age_begin Age begin
+#' @param age_end Age end
+#' @param num_pop_sims Number of population simulations
+#' @param num_fleets Number of fleets
+#' @param num_rec_models Number of Recruit Modules
+#' @param discards_present Are Discards present? FALSE by default
+#' @param seed Random Number seed. By Default, generates a pesdorandom number.

--- a/man/agepro_inp_model.Rd
+++ b/man/agepro_inp_model.Rd
@@ -47,9 +47,11 @@ File Functionality is based on AGEPRO-CoreLib implementation
 \if{html}{\out{<a id="method-agepro_inp_model-new"></a>}}
 \if{latex}{\out{\hypertarget{method-agepro_inp_model-new}{}}}
 \subsection{Method \code{new()}}{
-Initializes an instance of the AGEPRO model with default blank keyword
-parameter values, by using the default
-\link[=general_params]{general_params} values:
+Initializes an instance of the AGEPRO model with AGEPRO input file
+format functions. A default model can be initialized without setting
+\link[=general_params]{general_params} parameter values. The default
+values for the default model is:
+
 \itemize{
 \item Projection years: From \code{yr_start} 0 to \code{yr_end} 2
 \item Ages: From \code{age_begin} 1 to \code{age_end} 6

--- a/man/agepro_inp_model.Rd
+++ b/man/agepro_inp_model.Rd
@@ -60,12 +60,41 @@ parameter values, by using the default
 \item Pseudo-Randomly generated \code{seed}
 }
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{agepro_inp_model$new(enable_cat_print = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{agepro_inp_model$new(
+  yr_start = 0,
+  yr_end = 2,
+  age_begin = 1,
+  age_end = 6,
+  num_pop_sims = 1000,
+  num_fleets = 1,
+  num_rec_models = 1,
+  discards_present = 0,
+  seed = sample.int(1e+08, 1),
+  enable_cat_print = FALSE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
+\item{\code{yr_start}}{First Year of Projection}
+
+\item{\code{yr_end}}{Last Year of Projection}
+
+\item{\code{age_begin}}{Age begin}
+
+\item{\code{age_end}}{Age end}
+
+\item{\code{num_pop_sims}}{Number of population simulations}
+
+\item{\code{num_fleets}}{Number of fleets}
+
+\item{\code{num_rec_models}}{Number of Recruit Modules}
+
+\item{\code{discards_present}}{Are Discards present? FALSE by default}
+
+\item{\code{seed}}{Random Number seed. By Default, generates a pesdorandom number.}
+
 \item{\code{enable_cat_print}}{Logical flag to show target function's \strong{cli} \code{\link[cli:cat_line]{cat_print}}
 messages to be seen on console. In this instance, this is set to FALSE.}
 }

--- a/man/agepro_inp_model.Rd
+++ b/man/agepro_inp_model.Rd
@@ -70,7 +70,7 @@ parameter values, by using the default
   num_rec_models = 1,
   discards_present = 0,
   seed = sample.int(1e+08, 1),
-  enable_cat_print = FALSE
+  enable_cat_print = TRUE
 )}\if{html}{\out{</div>}}
 }
 
@@ -96,7 +96,7 @@ parameter values, by using the default
 \item{\code{seed}}{Random Number seed. By Default, generates a pesdorandom number.}
 
 \item{\code{enable_cat_print}}{Logical flag to show target function's \strong{cli} \code{\link[cli:cat_line]{cat_print}}
-messages to be seen on console. In this instance, this is set to FALSE.}
+messages to be seen on console. In this instance, this is set to TRUE}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/agepro_model.Rd
+++ b/man/agepro_model.Rd
@@ -111,7 +111,8 @@ Initializes the instance of the AGEPRO Model
   num_fleets,
   num_rec_models,
   discards_present = FALSE,
-  seed = sample.int(1e+08, 1)
+  seed = sample.int(1e+08, 1),
+  enable_cat_print = TRUE
 )}\if{html}{\out{</div>}}
 }
 
@@ -134,7 +135,11 @@ Initializes the instance of the AGEPRO Model
 
 \item{\code{discards_present}}{Are Discards present? FALSE by default}
 
-\item{\code{seed}}{Random Number seed. A pesdorandom number is set as default.}
+\item{\code{seed}}{Random Number seed. By Default, generates a pesdorandom number.}
+
+\item{\code{enable_cat_print}}{Logical flag to show target function's \strong{cli}
+\code{\link[cli:cat_line]{cat_print}} messages to be seen on console. By default,
+this is set to TRUE.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/case_id.Rd
+++ b/man/case_id.Rd
@@ -20,7 +20,7 @@ Input title identifying model attributes
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-case_id-initalize}{\code{case_id$initalize()}}
+\item \href{#method-case_id-new}{\code{case_id$new()}}
 \item \href{#method-case_id-print}{\code{case_id$print()}}
 \item \href{#method-case_id-read_inp_lines}{\code{case_id$read_inp_lines()}}
 \item \href{#method-case_id-get_inp_lines}{\code{case_id$get_inp_lines()}}
@@ -28,14 +28,21 @@ Input title identifying model attributes
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-case_id-initalize"></a>}}
-\if{latex}{\out{\hypertarget{method-case_id-initalize}{}}}
-\subsection{Method \code{initalize()}}{
+\if{html}{\out{<a id="method-case_id-new"></a>}}
+\if{latex}{\out{\hypertarget{method-case_id-new}{}}}
+\subsection{Method \code{new()}}{
 Initialize Class
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{case_id$initalize()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{case_id$new(model_name = NULL)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{model_name}}{Character string that describes the projection model}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-case_id-print"></a>}}

--- a/man/general_params.Rd
+++ b/man/general_params.Rd
@@ -72,7 +72,8 @@ Starts an instances of the AGEPRO Model
   num_fleets = 1,
   num_rec_models = 1,
   discards_present = FALSE,
-  seed = sample.int(1e+08, 1)
+  seed = sample.int(1e+08, 1),
+  enable_cat_print = TRUE
 )}\if{html}{\out{</div>}}
 }
 
@@ -96,6 +97,9 @@ Starts an instances of the AGEPRO Model
 \item{\code{discards_present}}{discards_present}
 
 \item{\code{seed}}{Random Number seed}
+
+\item{\code{enable_cat_print}}{Logical flag to show target function's messages on console.
+By Default, set to TRUE.}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
In addition to resolving #64, README was updated to better reflect current state of the package.

- agepro_inp_model can now be instantiated with general parameters to be more consistent with agepro_model and agepro_json_model.  (#64) 
   - Generating default agepro_inp_model is with `agepro_inp_model$new()` remains the same, 
   - Fixup/Improve WARNING messages for NULL Recruitment Model Data and Invalid Bootstrap File (#64)
- Fixup cli inconsistencies with optional options
- New agepro_models now have default CASEID
- Update README