### PR TITLE
Simple Unit tests (w/ testthat)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+*_snaps

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,3 +54,6 @@ Collate:
     'user_percentile_summary.R'
     'utils.R'
     'validation.R'
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/R/agepro_model.R
+++ b/R/agepro_model.R
@@ -50,11 +50,6 @@ agepro_model <- R6Class(
       private$.ver_jsonfile_format = 0
       private$setup_ver_rpackage()
 
-      assert_number(age_begin, lower = 0, upper = 1)
-      assert_number(num_fleets, lower = 1)
-      assert_number(num_rec_models, lower = 1)
-      assert_number(num_pop_sims, lower = 1)
-
       #Set GENERAL
       self$general <- general_params$new(yr_start,
                                          yr_end,
@@ -81,6 +76,7 @@ agepro_model <- R6Class(
 
 
       cli::cli_alert_success("Done")
+      invisible(self)
     },
 
     #' @description
@@ -910,7 +906,7 @@ agepro_inp_model <- R6Class(
       }
 
       ##Verify that input file location is valid
-      assert_file_exists(inpfile, access = "r", extension = "inp")
+      checkmate::assert_file_exists(inpfile, access = "r", extension = "inp")
 
       tryCatch(
         {

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(ageproR)
+
+test_check("ageproR")

--- a/tests/testthat/test-agepro_model.R
+++ b/tests/testthat/test-agepro_model.R
@@ -1,0 +1,41 @@
+test_that("multiplication works", {
+  expect_equal(2 * 2, 4)
+})
+
+
+# Test case: Create a agepro_model with:
+# - yr_start = 2019
+# - yr_end = 2026
+# - age_begin = 1
+# - age_end = 32
+# - num_pop_sims = 1000
+# - num_fleets = 4
+# - num_recruits = 1
+# - seed = 300
+test_that("New agepro_model (Year: 2019-2026, Age: 1-32, num_pop_sims: 1000, num_fleets: 4, 1 NULL Recruitment, discards: 0, seed: 300), and NULL Bootstrap file", {
+  expect_snapshot(ageproR::agepro_model$new(2019,2026,1,32,1000,4,1,0,300), cnd_class = TRUE)
+})
+
+
+#Test that Opening inst/test-example4,inp works
+test_that("Opening inst/test-example4.inp is imported to test agepro_inp_model", {
+  expect_snapshot(test <- ageproR::agepro_inp_model$new(seed=300), cnd_class = TRUE)
+  expect_snapshot(test$read_inp(file.path(here::here(),"inst/test-example4.inp")), cnd_class = TRUE)
+})
+
+#Test that Opening inst/test-example4.inp works, and Set to Bootstrap file
+test_that("Setting inst/Example1.BSN to test agepro_inp_model works",{
+  expect_snapshot(test <- ageproR::agepro_inp_model$new(seed=300), cnd_class = TRUE)
+  expect_snapshot(test$read_inp(file.path(here::here(),"inst/test-example4.inp")), cnd_class = TRUE)
+  expect_snapshot(test$set_bootstrap_filename(file.path(here::here(),"inst/Example1.BSN")), cnd_class = TRUE)
+})
+
+#Can that Opening inst/test-example4.inp works, and Set to Bootstrap file be exported to agepro_json_model class?
+test_that("Import 'test' agepro_inp_model class data to 'json_test' agepro_json_model class",{
+  expect_snapshot(test <- ageproR::agepro_inp_model$new(seed=300), cnd_class = TRUE)
+  expect_snapshot(test$read_inp(file.path(here::here(),"inst/test-example4.inp")), cnd_class = TRUE)
+  expect_snapshot(test_json <- ageproR::agepro_json_model$new(0,9,0,1,1000,4,1,0,300), cnd_class = TRUE)
+  expect_snapshot(test_json$import_agepro_inp_model(test), cnd_class = TRUE)
+})
+
+


### PR DESCRIPTION
- Included support for **testthat**
  - Added basic `agepro_model` unit tests  (#48)
- removed redundant parameter checks for `general_params` in **agepro_model**